### PR TITLE
Preparing to publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,76 @@
 [![Build Status](https://img.shields.io/travis/18F/accordion/master.svg)](https://travis-ci.org/18F/accordion)
 [![Test Coverage](https://img.shields.io/codecov/c/github/18F/accordion/master.svg)](https://codecov.io/github/18F/accordion)
 
-A simple, 508 compliant JavaScript accordion.
+# About
+A simple, accessible, 508-compliant JavaScript accordion. 
 
-A work in progress.
+# Getting started
+## Download
+### Via npm (coming soon)
+```
+npm install @18f/accordion
+```
 
+## Set up your HTML
+
+```
+	<ul class="js-accordion">
+	    <li>
+	      <button>
+	        First Amendment
+	      </button>
+	      <div>
+	        <p>
+	        Congress shall make no law respecting an establishment of religion, or prohibiting the free exercise thereof; or abridging the freedom of speech, or of the press; or the right of the people peaceably to assemble, and to petition the Government for a redress of grievances.
+	        </p>
+	      </div>
+	    </li>
+	    <li>
+	      <button>
+	        Second Amendment
+	      </button>
+	      <div>
+	        <p>
+	        A well regulated Militia, being necessary to the security of a free State, the right of the people to keep and bear Arms, shall not be infringed.
+	        </p>
+	      </div>
+	    </li>
+   </ul>
+```
+
+Simply create a series of `<button>` elements followed by `<div>`s and this will take care of the rest, adding the proper ARIA attributes.
+
+
+## Initialize
+In whichever file you initialize your JavaScript components, initialize the accordion like so:
+
+```
+	var accordion = require('@18f/accordion');
+
+	// Optional configurion objects
+	var selectors = { ... };
+	var opts = { ... };
+
+	new accordion.Accordion(selectors, opts);
+```
+
+
+# Configuration
+The constructor accepts an optional hash of selectors as its first parameter:
+
+- `body`: CSS selector of the outer element that contains the accordion items. _Default_: `.js-accordion`
+
+- `trigger`: CSS selector for the elements to turn into the accordion triggers. The component will look for these items' next sibling to turn into the accordion content that is hidden and revealed. _Default_: `button`
+
+You can also pass a hash of options. Currently, the only option is:
+
+- `collapseOthers`: Boolean for whether or not to collapse all other panels when one panel is open. _Default_: `false`
+
+# Styling
+You're free to add classes and style your markup however you please, but in order to hide the content, you'll need to add styles to those elements when `[aria-hidden="true"]`. To style the buttons when they panel is open vs closed, target `[aria-expanded="true"]`.
+
+
+# License
 ## Public domain
 
 This project is in the worldwide [public domain](LICENSE.md). As stated in [CONTRIBUTING](CONTRIBUTING.md):

--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ The constructor accepts an optional hash of selectors as its first parameter:
 You can also pass a hash of options. Currently, the only option is:
 
 - `collapseOthers`: Boolean for whether or not to collapse all other panels when one panel is open. _Default_: `false`
+- `customHiding`: Boolean for whether or not to use your own CSS to hide collapsed content areas. _Default_: `false`
 
 # Styling
-You're free to add classes and style your markup however you please, but in order to hide the content, you'll need to add styles to those elements when `[aria-hidden="true"]`. To style the buttons when they panel is open vs closed, target `[aria-expanded="true"]`.
+You're free to add classes and style your markup however you please. By default, the component sets any content element with `[aria-hidden="true"]` to `display: none` inline, but you can override this to use your own custom hiding styles with the `customHiding` property. To style the buttons when they panel is open vs closed, target `[aria-expanded="true"]`.
 
 
 # License

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# accordion
+# 18F Simple Accordion
 
 [![Build Status](https://img.shields.io/travis/18F/accordion/master.svg)](https://travis-ci.org/18F/accordion)
 [![Test Coverage](https://img.shields.io/codecov/c/github/18F/accordion/master.svg)](https://codecov.io/github/18F/accordion)

--- a/example/init.js
+++ b/example/init.js
@@ -1,5 +1,5 @@
 'use strict';
 
-var Accordion = require('..');
+var accordion = require('..');
 
-new Accordion();
+new accordion.Accordion();

--- a/example/main.js
+++ b/example/main.js
@@ -1563,9 +1563,6 @@ var _ = require('underscore');
 var defaultOpts = {
   collapseOthers: false,
   customHiding: false,
-  classes: {
-    expandedButton: 'accordion-trigger--expanded'
-  }
 };
 
 var defaultSelectors = {
@@ -1620,7 +1617,6 @@ Accordion.prototype.expand = function(button) {
   }
   var content = document.getElementById(button.getAttribute('aria-controls'));
   button.setAttribute('aria-expanded', 'true');
-  button.classList.add(this.opts.classes.expandedButton);
   content.setAttribute('aria-hidden', 'false');
   this.setStyles(content);
 };
@@ -1628,7 +1624,6 @@ Accordion.prototype.expand = function(button) {
 Accordion.prototype.collapse = function(button) {
   var content = document.getElementById(button.getAttribute('aria-controls'));
   button.setAttribute('aria-expanded', 'false');
-  button.classList.remove(this.opts.classes.expandedButton);
   content.setAttribute('aria-hidden', 'true');
   this.setStyles(content);
 };

--- a/example/main.js
+++ b/example/main.js
@@ -1,9 +1,9 @@
 (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
 
-var Accordion = require('..');
+var accordion = require('..');
 
-new Accordion();
+new accordion.Accordion();
 
 },{"..":3}],2:[function(require,module,exports){
 //     Underscore.js 1.8.3
@@ -1562,6 +1562,7 @@ var _ = require('underscore');
 
 var defaultOpts = {
   collapseOthers: false,
+  customHiding: false,
   classes: {
     expandedButton: 'accordion-trigger--expanded'
   }
@@ -1579,7 +1580,8 @@ var Accordion = function(selectors, opts) {
   this.body = document.querySelector(this.selectors.body);
   this.triggers = this.findTriggers();
 
-  this.body.addEventListener('click', this.handleClickBody.bind(this));
+  this.listeners = [];
+  this.addEventListener(this.body, 'click', this.handleClickBody.bind(this));
 };
 
 Accordion.prototype.handleClickBody = function(e) {
@@ -1604,6 +1606,7 @@ Accordion.prototype.setAria = function(trigger, index) {
   trigger.setAttribute('aria-expanded', 'false');
   content.setAttribute('id', contentID);
   content.setAttribute('aria-hidden', 'true');
+  this.setStyles(content);
 };
 
 Accordion.prototype.toggle = function(elm) {
@@ -1619,6 +1622,7 @@ Accordion.prototype.expand = function(button) {
   button.setAttribute('aria-expanded', 'true');
   button.classList.add(this.opts.classes.expandedButton);
   content.setAttribute('aria-hidden', 'false');
+  this.setStyles(content);
 };
 
 Accordion.prototype.collapse = function(button) {
@@ -1626,6 +1630,7 @@ Accordion.prototype.collapse = function(button) {
   button.setAttribute('aria-expanded', 'false');
   button.classList.remove(this.opts.classes.expandedButton);
   content.setAttribute('aria-hidden', 'true');
+  this.setStyles(content);
 };
 
 Accordion.prototype.collapseAll = function() {
@@ -1642,6 +1647,31 @@ Accordion.prototype.expandAll = function() {
   });
 };
 
-module.exports = Accordion;
+Accordion.prototype.setStyles = function(content) {
+  var prop = content.getAttribute('aria-hidden') === 'true' ? 'none' : 'block';
+
+  if (!this.opts.customHiding) {
+    content.style.display = prop;
+  };
+};
+
+Accordion.prototype.addEventListener = function(elm, event, callback) {
+  if (elm) {
+    elm.addEventListener(event, callback);
+    this.listeners.push({
+      elm: elm,
+      event: event,
+      callback: callback
+    });
+  }
+};
+
+Accordion.prototype.destroy = function() {
+  this.listeners.forEach(function(listener) {
+    listener.elm.removeEventListener(listener.event, listener.callback);
+  });
+};
+
+module.exports = { Accordion: Accordion };
 
 },{"underscore":2}]},{},[1]);

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "accordion",
+  "name": "@18f/accordion",
+  "author": "18F",
   "version": "0.1.0",
-  "description": "",
+  "description": "18F Simple Accordion",
   "repository": {
     "type": "git",
     "url": "git://github.com/18F/accordion.git"
   },
   "scripts": {
     "build": "browserify example/init.js > example/main.js",
-    "watch": "watchify example/init.js -o example/main.js",
     "test": "mochify tests/accordion.js"
   },
   "main": "src/accordion.js",
@@ -18,7 +18,9 @@
   "devDependencies": {
     "chai": "^3.2.0",
     "mocha": "^2.2.5",
-    "mochify": "^2.13.0",
-    "watchify": "^3.6.1"
+    "mochify": "^2.13.0"
+  },
+  "bugs": {
+    "url": "https://github.com/18f/accordion/issues"
   }
 }

--- a/src/accordion.js
+++ b/src/accordion.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 
 var defaultOpts = {
   collapseOthers: false,
+  customHiding: false,
   classes: {
     expandedButton: 'accordion-trigger--expanded'
   }
@@ -47,6 +48,7 @@ Accordion.prototype.setAria = function(trigger, index) {
   trigger.setAttribute('aria-expanded', 'false');
   content.setAttribute('id', contentID);
   content.setAttribute('aria-hidden', 'true');
+  this.setStyles(content);
 };
 
 Accordion.prototype.toggle = function(elm) {
@@ -62,6 +64,7 @@ Accordion.prototype.expand = function(button) {
   button.setAttribute('aria-expanded', 'true');
   button.classList.add(this.opts.classes.expandedButton);
   content.setAttribute('aria-hidden', 'false');
+  this.setStyles(content);
 };
 
 Accordion.prototype.collapse = function(button) {
@@ -69,6 +72,7 @@ Accordion.prototype.collapse = function(button) {
   button.setAttribute('aria-expanded', 'false');
   button.classList.remove(this.opts.classes.expandedButton);
   content.setAttribute('aria-hidden', 'true');
+  this.setStyles(content);
 };
 
 Accordion.prototype.collapseAll = function() {
@@ -83,6 +87,14 @@ Accordion.prototype.expandAll = function() {
   this.triggers.forEach(function(trigger) {
     self.expand(trigger);
   });
+};
+
+Accordion.prototype.setStyles = function(content) {
+  var prop = content.getAttribute('aria-hidden') === 'true' ? 'none' : 'block';
+
+  if (!this.opts.customHiding) {
+    content.style.display = prop;
+  };
 };
 
 Accordion.prototype.addEventListener = function(elm, event, callback) {
@@ -102,4 +114,4 @@ Accordion.prototype.destroy = function() {
   });
 };
 
-module.exports = Accordion;
+module.exports = { Accordion: Accordion };

--- a/tests/accordion.js
+++ b/tests/accordion.js
@@ -3,7 +3,7 @@
 var chai = require('chai');
 var expect = chai.expect;
 
-var Accordion = require('../src/accordion');
+var Accordion = require('../src/accordion').Accordion;
 
 function isOpen(trigger, accordion) {
   return trigger.getAttribute('aria-expanded') === 'true' &&
@@ -51,6 +51,14 @@ describe('accordion', function() {
     expect(trigger.getAttribute('aria-expanded')).to.equal('false');
     expect(trigger.getAttribute('aria-controls')).to.equal('content-0');
     expect(content.getAttribute('aria-hidden')).to.equal('true');
+  });
+
+  it('should set styles to display: none', function() {
+    var trigger = this.accordion.triggers[0];
+    var content = document.getElementById('content-0');
+    expect(content.style.display).to.equal('none');
+    this.accordion.expand(trigger);
+    expect(content.style.display).to.equal('block');
   });
 
   it('should expand the item on click', function() {


### PR DESCRIPTION
- Adds a README
- Adds a method to set inline CSS to `display: none` when a content div is hidden so that users don't _need_ to have their own CSS for this. 
- Adds an options property to disable this inlining
- Adds a test for it
