### PR TITLE
Content prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Test Coverage](https://img.shields.io/codecov/c/github/18F/accordion/master.svg)](https://codecov.io/github/18F/accordion)
 
 # About
-A simple, accessible, 508-compliant JavaScript accordion. 
+A simple, accessible, 508-compliant JavaScript accordion.
 
 # Getting started
 ## Download
@@ -68,6 +68,7 @@ You can also pass a hash of options. Currently, the only option is:
 
 - `collapseOthers`: Boolean for whether or not to collapse all other panels when one panel is open. _Default_: `false`
 - `customHiding`: Boolean for whether or not to use your own CSS to hide collapsed content areas. _Default_: `false`
+- 'contentPrefix': String prefix for the content div IDs in order to have multiple accordions on the same page. _Default_: `accordion`
 
 # Styling
 You're free to add classes and style your markup however you please. By default, the component sets any content element with `[aria-hidden="true"]` to `display: none` inline, but you can override this to use your own custom hiding styles with the `customHiding` property. To style the buttons when they panel is open vs closed, target `[aria-expanded="true"]`.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ You can also pass a hash of options. Currently, the only option is:
 
 - `collapseOthers`: Boolean for whether or not to collapse all other panels when one panel is open. _Default_: `false`
 - `customHiding`: Boolean for whether or not to use your own CSS to hide collapsed content areas. _Default_: `false`
-- 'contentPrefix': String prefix for the content div IDs in order to have multiple accordions on the same page. _Default_: `accordion`
+- `contentPrefix`: String prefix for the content div IDs in order to have multiple accordions on the same page. _Default_: `accordion`
+- `openFirst`: Boolean for whether or not to open the first item by default. _Default_: `false
 
 # Styling
 You're free to add classes and style your markup however you please. By default, the component sets any content element with `[aria-hidden="true"]` to `display: none` inline, but you can override this to use your own custom hiding styles with the `customHiding` property. To style the buttons when they panel is open vs closed, target `[aria-expanded="true"]`.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm install @18f/accordion
    </ul>
 ```
 
-Simply create a series of `<button>` elements followed by `<div>`s and this will take care of the rest, adding the proper ARIA attributes.
+Simply create a series of `<button>` elements followed by `<div>`s and this will take care of the rest, adding the proper ARIA attributes. You can add custom IDs to the `<div>`s and the library will default to those. If you don't add IDs the library will generate them for you.
 
 
 ## Initialize

--- a/example/init.js
+++ b/example/init.js
@@ -2,4 +2,4 @@
 
 var accordion = require('..');
 
-new accordion.Accordion();
+new accordion.Accordion({}, {openFirst: true});

--- a/example/main.js
+++ b/example/main.js
@@ -1603,11 +1603,18 @@ Accordion.prototype.findTriggers = function() {
 };
 
 Accordion.prototype.setAria = function(trigger, index) {
-  var contentID = this.opts.contentPrefix + '-' + 'content-' + index;
   var content = trigger.nextElementSibling;
+  var contentID;
+
+  if (content.hasAttribute('id')) {
+    contentID = content.getAttribute('id');
+  } else {
+    contentID = this.opts.contentPrefix + '-' + 'content-' + index;
+    content.setAttribute('id', contentID);
+  }
+
   trigger.setAttribute('aria-controls', contentID);
   trigger.setAttribute('aria-expanded', 'false');
-  content.setAttribute('id', contentID);
   content.setAttribute('aria-hidden', 'true');
   this.setStyles(content);
 };

--- a/example/main.js
+++ b/example/main.js
@@ -3,7 +3,7 @@
 
 var accordion = require('..');
 
-new accordion.Accordion();
+new accordion.Accordion({}, {openFirst: true});
 
 },{"..":3}],2:[function(require,module,exports){
 //     Underscore.js 1.8.3
@@ -1563,6 +1563,8 @@ var _ = require('underscore');
 var defaultOpts = {
   collapseOthers: false,
   customHiding: false,
+  contentPrefix: 'accordion',
+  openFirst: false
 };
 
 var defaultSelectors = {
@@ -1579,6 +1581,10 @@ var Accordion = function(selectors, opts) {
 
   this.listeners = [];
   this.addEventListener(this.body, 'click', this.handleClickBody.bind(this));
+
+  if (this.opts.openFirst) {
+    this.expand(this.triggers[0]);
+  }
 };
 
 Accordion.prototype.handleClickBody = function(e) {
@@ -1597,7 +1603,7 @@ Accordion.prototype.findTriggers = function() {
 };
 
 Accordion.prototype.setAria = function(trigger, index) {
-  var contentID = 'content-' + index;
+  var contentID = this.opts.contentPrefix + '-' + 'content-' + index;
   var content = trigger.nextElementSibling;
   trigger.setAttribute('aria-controls', contentID);
   trigger.setAttribute('aria-expanded', 'false');

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@18f/accordion",
+  "name": "accordion",
   "author": "18F",
   "version": "0.1.0",
   "description": "18F Simple Accordion",

--- a/src/accordion.js
+++ b/src/accordion.js
@@ -45,11 +45,18 @@ Accordion.prototype.findTriggers = function() {
 };
 
 Accordion.prototype.setAria = function(trigger, index) {
-  var contentID = this.opts.contentPrefix + '-' + 'content-' + index;
   var content = trigger.nextElementSibling;
+  var contentID;
+
+  if (content.hasAttribute('id')) {
+    contentID = content.getAttribute('id');
+  } else {
+    contentID = this.opts.contentPrefix + '-' + 'content-' + index;
+    content.setAttribute('id', contentID);
+  }
+
   trigger.setAttribute('aria-controls', contentID);
   trigger.setAttribute('aria-expanded', 'false');
-  content.setAttribute('id', contentID);
   content.setAttribute('aria-hidden', 'true');
   this.setStyles(content);
 };

--- a/src/accordion.js
+++ b/src/accordion.js
@@ -5,6 +5,7 @@ var _ = require('underscore');
 var defaultOpts = {
   collapseOthers: false,
   customHiding: false,
+  contentPrefix: 'accordion',
 };
 
 var defaultSelectors = {
@@ -39,7 +40,7 @@ Accordion.prototype.findTriggers = function() {
 };
 
 Accordion.prototype.setAria = function(trigger, index) {
-  var contentID = 'content-' + index;
+  var contentID = this.opts.contentPrefix + '-' + 'content-' + index;
   var content = trigger.nextElementSibling;
   trigger.setAttribute('aria-controls', contentID);
   trigger.setAttribute('aria-expanded', 'false');

--- a/src/accordion.js
+++ b/src/accordion.js
@@ -6,6 +6,7 @@ var defaultOpts = {
   collapseOthers: false,
   customHiding: false,
   contentPrefix: 'accordion',
+  openFirst: false
 };
 
 var defaultSelectors = {
@@ -22,6 +23,10 @@ var Accordion = function(selectors, opts) {
 
   this.listeners = [];
   this.addEventListener(this.body, 'click', this.handleClickBody.bind(this));
+
+  if (this.opts.openFirst) {
+    this.expand(this.triggers[0]);
+  }
 };
 
 Accordion.prototype.handleClickBody = function(e) {

--- a/tests/accordion.js
+++ b/tests/accordion.js
@@ -7,13 +7,11 @@ var Accordion = require('../src/accordion').Accordion;
 
 function isOpen(trigger, accordion) {
   return trigger.getAttribute('aria-expanded') === 'true' &&
-    trigger.classList.contains(accordion.opts.classes.expandedButton) &&
     document.querySelector('#' + trigger.getAttribute('aria-controls')).getAttribute('aria-hidden') === 'false';
 }
 
 function isClosed(trigger, accordion) {
   return trigger.getAttribute('aria-expanded') === 'false' &&
-    !trigger.classList.contains(accordion.opts.classes.expandedButton) &&
     document.querySelector('#' + trigger.getAttribute('aria-controls')).getAttribute('aria-hidden') === 'true';
 }
 
@@ -47,15 +45,15 @@ describe('accordion', function() {
 
   it('should set aria attributes', function() {
     var trigger = this.accordion.triggers[0];
-    var content = document.getElementById('content-0');
+    var content = document.getElementById('accordion-content-0');
     expect(trigger.getAttribute('aria-expanded')).to.equal('false');
-    expect(trigger.getAttribute('aria-controls')).to.equal('content-0');
+    expect(trigger.getAttribute('aria-controls')).to.equal('accordion-content-0');
     expect(content.getAttribute('aria-hidden')).to.equal('true');
   });
 
   it('should set styles to display: none', function() {
     var trigger = this.accordion.triggers[0];
-    var content = document.getElementById('content-0');
+    var content = document.getElementById('accordion-content-0');
     expect(content.style.display).to.equal('none');
     this.accordion.expand(trigger);
     expect(content.style.display).to.equal('block');


### PR DESCRIPTION
Adding the ability to set custom prefixes for the IDs of the content divs. This allows you to have more than one accordion instance on a page. 
