### PR TITLE
Creates new option to allow for statically generated content

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can also pass a hash of options. Currently, the only option is:
 - `customHiding`: Boolean for whether or not to use your own CSS to hide collapsed content areas. _Default_: `false`
 - `contentPrefix`: String prefix for the content div IDs in order to have multiple accordions on the same page. _Default_: `accordion`
 - `openFirst`: Boolean for whether or not to open the first item by default. _Default_: `false`
-- `overrideStatic`: Boolean for whether or not the accordion should override any attributes (`aria-hidden` and `aria-expanded`) that were rendered statically. _Default_: `false`
+- `reflectStatic`: Boolean for whether or not the accordion should reflect any attributes (`aria-hidden` and `aria-expanded`) that were rendered statically. _Default_: `false`
 
 # Styling
 You're free to add classes and style your markup however you please. By default, the component sets any content element with `[aria-hidden="true"]` to `display: none` inline, but you can override this to use your own custom hiding styles with the `customHiding` property. To style the buttons when they panel is open vs closed, target `[aria-expanded="true"]`.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ You can also pass a hash of options. Currently, the only option is:
 - `collapseOthers`: Boolean for whether or not to collapse all other panels when one panel is open. _Default_: `false`
 - `customHiding`: Boolean for whether or not to use your own CSS to hide collapsed content areas. _Default_: `false`
 - `contentPrefix`: String prefix for the content div IDs in order to have multiple accordions on the same page. _Default_: `accordion`
-- `openFirst`: Boolean for whether or not to open the first item by default. _Default_: `false
+- `openFirst`: Boolean for whether or not to open the first item by default. _Default_: `false`
+- `overrideStatic`: Boolean for whether or not the accordion should override any attributes (`aria-hidden` and `aria-expanded`) that were rendered statically. _Default_: `false`
 
 # Styling
 You're free to add classes and style your markup however you please. By default, the component sets any content element with `[aria-hidden="true"]` to `display: none` inline, but you can override this to use your own custom hiding styles with the `customHiding` property. To style the buttons when they panel is open vs closed, target `[aria-expanded="true"]`.

--- a/example/main.js
+++ b/example/main.js
@@ -16,7 +16,8 @@ var defaultOpts = {
   collapseOthers: false,
   customHiding: false,
   contentPrefix: 'accordion',
-  openFirst: false
+  openFirst: false,
+  reflectStatic: false
 };
 
 var defaultSelectors = {
@@ -73,6 +74,8 @@ Accordion.prototype.findTriggers = function() {
 Accordion.prototype.setAria = function(trigger, index) {
   var content = trigger.nextElementSibling;
   var contentID;
+  var initExpanded = 'false';
+  var initHidden = 'true';
 
   if (content.hasAttribute('id')) {
     contentID = content.getAttribute('id');
@@ -81,9 +84,14 @@ Accordion.prototype.setAria = function(trigger, index) {
     content.setAttribute('id', contentID);
   }
 
+  if (this.opts.reflectStatic) {
+    initExpanded = trigger.getAttribute('aria-expanded') || initExpanded;
+    initHidden = content.getAttribute('aria-hidden') || initHidden;
+  }
+
   trigger.setAttribute('aria-controls', contentID);
-  trigger.setAttribute('aria-expanded', 'false');
-  content.setAttribute('aria-hidden', 'true');
+  trigger.setAttribute('aria-expanded', initExpanded);
+  content.setAttribute('aria-hidden', initHidden);
   this.setStyles(content);
 };
 

--- a/src/accordion.js
+++ b/src/accordion.js
@@ -6,7 +6,8 @@ var defaultOpts = {
   collapseOthers: false,
   customHiding: false,
   contentPrefix: 'accordion',
-  openFirst: false
+  openFirst: false,
+  overrideStatic: false
 };
 
 var defaultSelectors = {
@@ -63,6 +64,8 @@ Accordion.prototype.findTriggers = function() {
 Accordion.prototype.setAria = function(trigger, index) {
   var content = trigger.nextElementSibling;
   var contentID;
+  var initExpanded = 'false';
+  var initHidden = 'true';
 
   if (content.hasAttribute('id')) {
     contentID = content.getAttribute('id');
@@ -71,9 +74,14 @@ Accordion.prototype.setAria = function(trigger, index) {
     content.setAttribute('id', contentID);
   }
 
+  if (this.opts.overrideStatic) {
+    initExpanded = trigger.getAttribute('aria-expanded') || initExpanded;
+    initHidden = content.getAttribute('aria-hidden') || initHidden;
+  }
+
   trigger.setAttribute('aria-controls', contentID);
-  trigger.setAttribute('aria-expanded', 'false');
-  content.setAttribute('aria-hidden', 'true');
+  trigger.setAttribute('aria-expanded', initExpanded);
+  content.setAttribute('aria-hidden', initHidden);
   this.setStyles(content);
 };
 

--- a/src/accordion.js
+++ b/src/accordion.js
@@ -7,7 +7,7 @@ var defaultOpts = {
   customHiding: false,
   contentPrefix: 'accordion',
   openFirst: false,
-  overrideStatic: false
+  reflectStatic: false
 };
 
 var defaultSelectors = {
@@ -74,7 +74,7 @@ Accordion.prototype.setAria = function(trigger, index) {
     content.setAttribute('id', contentID);
   }
 
-  if (this.opts.overrideStatic) {
+  if (this.opts.reflectStatic) {
     initExpanded = trigger.getAttribute('aria-expanded') || initExpanded;
     initHidden = content.getAttribute('aria-hidden') || initHidden;
   }

--- a/test/accordion.js
+++ b/test/accordion.js
@@ -70,7 +70,7 @@ describe('accordion', function() {
     var elm3 = document.querySelector('.accordion-3');
     this.accordion = new Accordion(elm1, {}, {collapseOthers: true});
     this.accordion2 = new Accordion(elm2, {}, {contentPrefix: 'second'});
-    this.accordion3 = new Accordion(elm3, {}, {overrideStatic: true});
+    this.accordion3 = new Accordion(elm3, {}, {reflectStatic: true});
   });
 
   it('should find triggers on init', function() {

--- a/test/accordion.js
+++ b/test/accordion.js
@@ -52,11 +52,25 @@ describe('accordion', function() {
       '<div class="accordion-2">' +
         '<button>Accordion 2 button</button>' +
         '<div>Some content</div>' +
+      '</div>' +
+      '<div class="accordion-3">' +
+        '<ul>' +
+          '<li>' +
+            '<button aria-expanded="true"></button>' +
+            '<div aria-hidden="false">Some content</div>' +
+          '</li>' +
+          '<li>' +
+            '<button></button>' +
+            '<div>Some content</div>' +
+          '</li>' +
+        '</ul>' +
       '</div>';
     var elm1 = document.querySelector('.accordion-1');
     var elm2 = document.querySelector('.accordion-2');
+    var elm3 = document.querySelector('.accordion-3');
     this.accordion = new Accordion(elm1, {}, {collapseOthers: true});
     this.accordion2 = new Accordion(elm2, {}, {contentPrefix: 'second'});
+    this.accordion3 = new Accordion(elm3, {}, {overrideStatic: true});
   });
 
   it('should find triggers on init', function() {
@@ -116,6 +130,30 @@ describe('accordion', function() {
       this.accordion2.expand(trigger2);
       expect(isOpen(trigger2)).to.be.true;
       expect(isOpen(trigger1)).to.be.false;
+    });
+  });
+
+  describe('page with statically-rendered static attributes', function() {
+    it('should have two triggers when it initializes', function() {
+      expect(this.accordion3.triggers.length).to.equal(2);
+    });
+
+    it('the first trigger should be open', function() {
+      var accordion3 = document.querySelector('.accordion-3');
+      var trigger = this.accordion3.triggers[0];
+      var content = accordion3.querySelector('#accordion-content-0');
+      expect(trigger.getAttribute('aria-expanded')).to.equal('true');
+      expect(trigger.getAttribute('aria-controls')).to.equal('accordion-content-0');
+      expect(content.getAttribute('aria-hidden')).to.equal('false');
+    });
+
+    it('the second trigger should not be open', function() {
+      var accordion3 = document.querySelector('.accordion-3');
+      var trigger = this.accordion3.triggers[1];
+      var content = accordion3.querySelector('#accordion-content-1');
+      expect(trigger.getAttribute('aria-expanded')).to.equal('false');
+      expect(trigger.getAttribute('aria-controls')).to.equal('accordion-content-1');
+      expect(content.getAttribute('aria-hidden')).to.equal('true');
     });
   });
 });


### PR DESCRIPTION
This PR allows enables a user create an accordion that reflects the ARIA attributes that have been statically generated on an accordion.

I added a few tests, and am trying to use it in [18/identity-site](https://github.com/18F/identity-site)

**to do so, add to list of options:**
```js
var elm = document.querySelector('.js-accordion');
this.accordion = new Accordion(elm, {}, {reflectStatic: true});
```

**Set in your HTML**
```html
<div class="js-accordion">
  <ul>
    <li>
      <button aria-expanded="true"></button>
      <div aria-hidden="false">Some content</div>
    </li>
    <li>
      <button></button>
      <div>Some content</div>
    </li>
  </ul>
</div>
```

cc @noahmanger 